### PR TITLE
sd: meshnode: packages reviewed and updated

### DIFF
--- a/communities/massmesh/meshnode/rpi-4/settings.sh
+++ b/communities/massmesh/meshnode/rpi-4/settings.sh
@@ -4,5 +4,3 @@ export VERSION="snapshots"
 
 export TARGET="bcm27xx/bcm2711"
 export PROFILE="rpi-4"
-
-export PACKAGES="${PACKAGES} kmod-usb-net-asix-ax88179 kmod-usb-net-rtl8152 python3-mm-cli autoygg-go"

--- a/communities/massmesh/meshnode/rpi-b-plus/settings.sh
+++ b/communities/massmesh/meshnode/rpi-b-plus/settings.sh
@@ -4,5 +4,3 @@ export VERSION="snapshots"
 
 export TARGET="bcm27xx/bcm2710"
 export PROFILE="rpi-3"
-
-export PACKAGES="${PACKAGES} -kmod-ath10k-ct kmod-usb-net-asix-ax88179 python3-mm-cli autoygg-go"

--- a/communities/massmesh/meshnode/settings.sh
+++ b/communities/massmesh/meshnode/settings.sh
@@ -2,14 +2,31 @@
 
 export EXTRA_IMAGE_NAME="massmesh-meshnode"
 
-# Packages for all mesh nodes
-
+## Routing
 export PACKAGES="${PACKAGES} yggdrasil cjdns" # mesh routing protocols yggdrasil and cjdns
 export PACKAGES="${PACKAGES} luci-app-yggdrasil luci-app-cjdns" # LuCI admin for yggdrasil and cjdns
+export PACKAGES="${PACKAGES} python3-mm-cli autoygg-go" # via repo.com/massmesh/mm-toolbox.git;
+
+## JQ fast CLI parsing one liner commands (for OpenWrt see: jshn.sh /lib/functions.sh && /usr/lib)
 export PACKAGES="${PACKAGES} jq" # jq for scripting json config changes
-# export PACKAGES="${PACKAGES} tor tor-fw-helper tor-resolve torsocks" # Tor
-# export PACKAGES="${PACKAGES} nodogsplash" # Captive portal - currently breaks peering and gateway
+
+## Creates a WAN interface, gains IP address from usb-tethered handheld celluar phone with USB connection
 export PACKAGES="${PACKAGES} kmod-usb-net-rndis" # USB Tethering
+
 export PACKAGES="${PACKAGES} kmod-usb-net-asix-ax88179 kmod-usb-net-rtl8152" # usb-ethernet kernel mods
+
+## USB Reset utility used for tethering or jammed Wi-Fi devices (see LiMe opkgs: watchping / watchdog)
 export PACKAGES="${PACKAGES} usbreset" # USB HC reset (host side, soft reset)
-export PACKAGES="${PACKAGES} python3" # Python3.8
+
+## NEW DESELECT
+# ~ Python3 "Light" is selected by python3-mm-cli
+# export PACKAGES="${PACKAGES} python3" # Python3.8
+# ~ package the source py files
+# export PACKAGES="${PACKAGES} python3-mm-cli-src" # via repo.com/massmesh/mm-toolbox.git;
+
+## OLD DESELECT
+# ~ Lost Tor support after yggdrasil CKR fixed throughput without need of proxy.
+# ~ Please revisit
+# export PACKAGES="${PACKAGES} tor tor-fw-helper tor-resolve torsocks" # Tor
+# ~ This should be re-enabled, we should be serving HTML or using opennds 9000
+# export PACKAGES="${PACKAGES} nodogsplash" # Captive portal - currently breaks peering and gateway

--- a/communities/massmesh/meshnode/settings.sh
+++ b/communities/massmesh/meshnode/settings.sh
@@ -1,32 +1,42 @@
 #!/bin/sh
-
 export EXTRA_IMAGE_NAME="massmesh-meshnode"
+
+
+## Optware Packages support for TLS/SSL/x509
+export PACKAGES="${PACKAGES} libustream-mbedtls ca-bundle ca-certificates"
 
 ## Routing
 export PACKAGES="${PACKAGES} yggdrasil cjdns" # mesh routing protocols yggdrasil and cjdns
-export PACKAGES="${PACKAGES} luci-app-yggdrasil luci-app-cjdns" # LuCI admin for yggdrasil and cjdns
-export PACKAGES="${PACKAGES} python3-mm-cli autoygg-go" # via repo.com/massmesh/mm-toolbox.git;
+export PACKAGES="${PACKAGES} luci-app-yggdrasil" # LuCI admin for yggdrasil
+export PACKAGES="${PACKAGES} luci-app-cjdns" # LuCI admin for cjdns
 
-## JQ fast CLI parsing one liner commands (for OpenWrt see: jshn.sh /lib/functions.sh && /usr/lib)
-export PACKAGES="${PACKAGES} jq" # jq for scripting json config changes
+## MassMesh Packages repo.com/massmesh/mm-toolbox.git
+export PACKAGES="${PACKAGES} python3-argh"
+export PACKAGES="${PACKAGES} python3-netaddr"
+export PACKAGES="${PACKAGES} python3-mm-cli-src"
+export PACKAGES="${PACKAGES} autoygg-go"
 
-## Creates a WAN interface, gains IP address from usb-tethered handheld celluar phone with USB connection
+## Python3 && Deps
+export PACKAGES="${PACKAGES} python3-light python3-urllib python3-logging"
+
+## JQ fast CLI parsing one liner commands
+# ~ for OpenWrt see: jshn.sh, /lib/functions.sh
+export PACKAGES="${PACKAGES} jq"
+
+## Creates a WAN interface
+# ~ Gain IP address from USB tethered celluar phones
 export PACKAGES="${PACKAGES} kmod-usb-net-rndis" # USB Tethering
+export PACKAGES="${PACKAGES} kmod-usb-net-asix-ax88179 kmod-usb-net-rtl8152" # USB Adapters
 
-export PACKAGES="${PACKAGES} kmod-usb-net-asix-ax88179 kmod-usb-net-rtl8152" # usb-ethernet kernel mods
-
-## USB Reset utility used for tethering or jammed Wi-Fi devices (see LiMe opkgs: watchping / watchdog)
+## USB WAN Support files
+# ~ Reset utility used for tethering or jammed Wi-Fi devices
+# ~ (see LiMe opkgs: watchping / watchdog)
 export PACKAGES="${PACKAGES} usbreset" # USB HC reset (host side, soft reset)
 
-## NEW DESELECT
-# ~ Python3 "Light" is selected by python3-mm-cli
-# export PACKAGES="${PACKAGES} python3" # Python3.8
-# ~ package the source py files
-# export PACKAGES="${PACKAGES} python3-mm-cli-src" # via repo.com/massmesh/mm-toolbox.git;
 
-## OLD DESELECT
+## DESELECTED ##########################################################################
 # ~ Lost Tor support after yggdrasil CKR fixed throughput without need of proxy.
-# ~ Please revisit
 # export PACKAGES="${PACKAGES} tor tor-fw-helper tor-resolve torsocks" # Tor
+#
 # ~ This should be re-enabled, we should be serving HTML or using opennds 9000
 # export PACKAGES="${PACKAGES} nodogsplash" # Captive portal - currently breaks peering and gateway


### PR DESCRIPTION
rpi-b-plus: rpi4: cleanup -> moved to meshnode

note:
- apu2: settings.sh needs review and update
- rpi3: removed deselect of ath10k-ct driver (?)
- python3: deselected in favor of python3-light
- mesh toolbox/mm-cli: we can now select the src package for py files