### PR TITLE
rpi-4: investigate eeprom bootloader upgrade support

### DIFF
--- a/communities/massmesh/meshnode/rpi-4/settings.sh
+++ b/communities/massmesh/meshnode/rpi-4/settings.sh
@@ -4,3 +4,7 @@ export VERSION="snapshots"
 
 export TARGET="bcm27xx/bcm2711"
 export PROFILE="rpi-4"
+export PACKAGES="${PACKAGES} bcm27xx-eeprom bcm27xx-userland"
+# ~ selects the following:
+# libpci libkmod pciutils bcm27xx-userland blkid bcm27xx-eeprom
+


### PR DESCRIPTION
tested on rpi-4 -- related to   [#81]   
  
  
```
root@OpenWrt:/tmp# vcgencmd bootloader_config
BOOT_UART=0
WAKE_ON_GPIO=1
POWER_OFF_ON_HALT=0
FREEZE_VERSION=0                                                                 
```