### PR TITLE
ci: use the refresh flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           command: sed -i '/BIN_DIR=/ s/$PROFILE_PATH\/bin\/$3/\/tmp\/artifacts\/$1\/$2\/$3/' ./build
       - run:
           name: Build << parameters.community >> << parameters.profile >> << parameters.device >>
-          command: './build << parameters.community >> << parameters.profile >> << parameters.device >>'
+          command: 'REFRESH=1 ./build << parameters.community >> << parameters.profile >> << parameters.device >>'
       - add_ssh_keys:
           fingerprints:
             - "f6:6d:a4:c9:4e:93:86:41:57:7c:70:0c:27:fb:b9:be"

--- a/meta
+++ b/meta
@@ -74,17 +74,13 @@ download() {
 		&& rm $(echo $TARGET | cut -d/ -f2) \
 		|| : # always re-symlink
 	if [ -n "${REFRESH}" ]; then
-		if [ -e ${IB_DIR}/*.xz ]; then
-			if [ $(stat -c %s ${IB_DIR}/*.xz) -gt 25000000 ];
-			  then rm -rf "${IB_DIR}" && mkdir -p "$IB_DIR"
-			else
-				exit 99
-			fi
+		if [ -e ${IB_DIR}/openwrt-imagebuilder-*.tar.xz ]; then
+			echo "Refresh: OpenWrt IB found and removed: ${IB_DIR}"
+			echo "Refresh: $(basename ${IB_DIR}/openwrt-imagebuilder-*.tar.xz)"
+			rm -rf "${IB_DIR}" && mkdir -p "$IB_DIR"
 		else
-			:
+			echo "Refresh: No IB found: ${IB_DIR}"
 		fi
-	else
-		:
 	fi
 	ln -s "$IB_DIR" .
 	cd "$IB_DIR" || exit


### PR DESCRIPTION
i'm interested in seeing if this gets hit (cache left over in /dev/shm ?? hmm)
or is `gpg --verify` the issue? i thought we saw shasums causing build headaches too, right?