### PR TITLE
sd: initital support for ubnt edgerouter lite and closes #86

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           command: sed -i '/BIN_DIR=/ s/$PROFILE_PATH\/bin\/$3/\/tmp\/artifacts\/$1\/$2\/$3/' ./build
       - run:
           name: Build << parameters.community >> << parameters.profile >> << parameters.device >>
-          command: './build << parameters.community >> << parameters.profile >> << parameters.device >>'
+          command: 'REFRESH=1 ./build << parameters.community >> << parameters.profile >> << parameters.device >>'
       - add_ssh_keys:
           fingerprints:
             - "f6:6d:a4:c9:4e:93:86:41:57:7c:70:0c:27:fb:b9:be"

--- a/communities/massmesh/meshnode/ubnt_edgerouter-lite/files/etc/config/network
+++ b/communities/massmesh/meshnode/ubnt_edgerouter-lite/files/etc/config/network
@@ -1,0 +1,31 @@
+config interface 'loopback'
+	option ifname 'lo'
+	option proto 'static'
+	option ipaddr '127.0.0.1'
+	option netmask '255.0.0.0'
+
+config globals 'globals'
+
+config interface 'lan'
+	option type 'bridge'
+	option ifname 'eth0'
+	option proto 'static'
+	option netmask '255.255.255.0'
+	option ip6assign '64'
+	option ipaddr '192.168.42.1'
+	option ip6hint '0'
+
+config interface 'yggdrasil'
+	option ifname 'ygg0'
+	option proto 'none'
+	option delegate '0'
+
+config interface 'mesh'
+	option proto 'none'
+	option auto '1'
+	option ifname 'eth0.3'
+	option type 'bridge'
+
+config interface 'wan'
+	option ifname 'eth1'
+	option proto 'dhcp'

--- a/communities/massmesh/meshnode/ubnt_edgerouter-lite/settings.sh
+++ b/communities/massmesh/meshnode/ubnt_edgerouter-lite/settings.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+export VERSION="snapshots"
+
+export TARGET="octeon/generic"
+export PROFILE="ubnt_edgerouter-lite"
+
+export PACKAGES="${PACKAGES} -python3-argh -python3-netaddr -python3-mm-cli-src -autoygg-go"
+
+
+# export PROFILE="ubnt_edgerouter"

--- a/meta
+++ b/meta
@@ -74,17 +74,13 @@ download() {
 		&& rm $(echo $TARGET | cut -d/ -f2) \
 		|| : # always re-symlink
 	if [ -n "${REFRESH}" ]; then
-		if [ -e ${IB_DIR}/*.xz ]; then
-			if [ $(stat -c %s ${IB_DIR}/*.xz) -gt 25000000 ];
-			  then rm -rf "${IB_DIR}" && mkdir -p "$IB_DIR"
-			else
-				exit 99
-			fi
+		if [ -e ${IB_DIR}/openwrt-imagebuilder-*.tar.xz ]; then
+			echo "Refresh: OpenWrt IB found and removed: ${IB_DIR}"
+			echo "Refresh: $(basename ${IB_DIR}/openwrt-imagebuilder-*.tar.xz)"
+			rm -rf "${IB_DIR}" && mkdir -p "$IB_DIR"
 		else
-			:
+			echo "Refresh: No IB found: ${IB_DIR}"
 		fi
-	else
-		:
 	fi
 	ln -s "$IB_DIR" .
 	cd "$IB_DIR" || exit


### PR DESCRIPTION
testing on 5 port, but the 3 port "lite" profile (i think) works fine.
- flashed openwrt-19x image to USB
- opkg installed luci and other apps
- performed systemupgrade with the .tar file via build
  - `./build massmesh meshnode ubnt_edgerouter-lite`

this thing runs hot with any firmware. i doubt if the accelerated switching or NAT is supported.. (1mn pps)

