### PR TITLE
Switch to defining our Yggdrasil Peers as InterfacePeers instead.

### DIFF
--- a/communities/massmesh/meshnode/files/etc/uci-defaults/zz-massmesh-firstboot.sh
+++ b/communities/massmesh/meshnode/files/etc/uci-defaults/zz-massmesh-firstboot.sh
@@ -27,16 +27,21 @@ uci set firewall.@rule[-1].target='ACCEPT'
 uci commit
 
 # Add yggdrasil peers
-uci add yggdrasil peer
-uci set yggdrasil.@peer[-1].uri='tcp://50.236.201.218:56088'
-uci add yggdrasil peer
-uci set yggdrasil.@peer[-1].uri='tcp://45.76.166.128:12345'
-uci add yggdrasil peer
-uci set yggdrasil.@peer[-1].uri='tcp://45.77.107.150:34660'
-uci add yggdrasil peer
-uci set yggdrasil.@peer[-1].uri='tcp://108.175.10.127:61216'
-uci add yggdrasil peer
-uci set yggdrasil.@peer[-1].uri='tcp://198.58.100.240:44478'
+uci add yggdrasil interface_peer
+uci set yggdrasil.@interface_peer[-1].uri='tcp://50.236.201.218:56088'
+uci set yggdrasil.@interface_peer[-1].interface='eth1'
+uci add yggdrasil interface_peer
+uci set yggdrasil.@interface_peer[-1].uri='tcp://45.76.166.128:12345'
+uci set yggdrasil.@interface_peer[-1].interface='eth1'
+uci add yggdrasil interface_peer
+uci set yggdrasil.@interface_peer[-1].uri='tcp://45.77.107.150:34660'
+uci set yggdrasil.@interface_peer[-1].interface='eth1'
+uci add yggdrasil interface_peer
+uci set yggdrasil.@interface_peer[-1].uri='tcp://108.175.10.127:61216'
+uci set yggdrasil.@interface_peer[-1].interface='eth1'
+uci add yggdrasil interface_peer
+uci set yggdrasil.@interface_peer[-1].uri='tcp://198.58.100.240:44478'
+uci set yggdrasil.@interface_peer[-1].interface='eth1'
 uci commit
 
 # Add yggdrasil tunnel routing config

--- a/communities/massmesh/settings.sh
+++ b/communities/massmesh/settings.sh
@@ -6,3 +6,5 @@ export REPOS=`echo -en "${REPOS}\n# Massmesh package repo\nsrc/gz custom http://
 export PACKAGES="${PACKAGES} luci luci-theme-material" # Luci for web configuration
 export PACKAGES="${PACKAGES} kmod-ath10k-ct ath10k-firmware-qca988x-ct -kmod-ath10k-ct-smallbuffers" # QCA wireless firmware for mesh mode
 
+# Make sure wolfssl is excluded, we use openssl
+export PACKAGES="${PACKAGES} -wpad-basic-wolfssl -libustream-wolfssl"


### PR DESCRIPTION
This way we avoid Yggdrasil ever trying to peer with them over the ygg0
interface.